### PR TITLE
Set fetch timeout to 5 seconds

### DIFF
--- a/src/core/login/login-learnus.ts
+++ b/src/core/login/login-learnus.ts
@@ -26,6 +26,7 @@ async function fetch1(username: string, password: string) {
         username,
         password,
       }),
+      signal: AbortSignal.timeout(5000),
     }
   )
 
@@ -54,6 +55,7 @@ async function fetch2(
       username,
       password,
     }),
+    signal: AbortSignal.timeout(5000),
   })
 
   return parseInputTagsFromHtml(await response.text())
@@ -86,6 +88,7 @@ async function fetch3(
         username,
         password,
       }),
+      signal: AbortSignal.timeout(5000),
     }
   )
 
@@ -129,6 +132,7 @@ async function fetch4(
       username,
       password,
     }),
+    signal: AbortSignal.timeout(5000),
   })
 
   return parseInputTagsFromHtml(await response.text())
@@ -157,11 +161,14 @@ async function fetch5(
       username,
       password,
     }),
+    signal: AbortSignal.timeout(5000),
   })
 }
 
 async function fetch6() {
-  await fetch(`${LEARNUS_ORIGIN}/passni/spLoginProcess.php`)
+  await fetch(`${LEARNUS_ORIGIN}/passni/spLoginProcess.php`, {
+    signal: AbortSignal.timeout(5000),
+  })
 }
 
 function stringToHex(raw: string) {

--- a/src/core/login/login-portal.ts
+++ b/src/core/login/login-portal.ts
@@ -19,6 +19,7 @@ async function fetch1() {
       a: 'aaaa',
       b: 'bbbb',
     }),
+    signal: AbortSignal.timeout(5000),
   })
 
   return parseInputTagsFromHtml(await response.text())
@@ -39,6 +40,7 @@ async function fetch2(data1: Record<string, string>) {
       a: 'aaaa',
       b: 'bbbb',
     }),
+    signal: AbortSignal.timeout(5000),
   })
 
   return parseInputTagsFromHtml(await response.text())
@@ -63,13 +65,18 @@ async function fetch3(data2: Record<string, string>) {
       a: 'aaaa',
       b: 'bbbb',
     }),
+    signal: AbortSignal.timeout(5000),
   })
 }
 
 async function fetch4() {
-  await fetch(`${PORTAL_ORIGIN}/passni/spLoginProcess.jsp`)
+  await fetch(`${PORTAL_ORIGIN}/passni/spLoginProcess.jsp`, {
+    signal: AbortSignal.timeout(5000),
+  })
 }
 
 async function fetch5() {
-  await fetch(`${PORTAL_ORIGIN}/com/lgin/SsoCtr/j_login_sso.do`)
+  await fetch(`${PORTAL_ORIGIN}/com/lgin/SsoCtr/j_login_sso.do`, {
+    signal: AbortSignal.timeout(5000),
+  })
 }

--- a/src/core/login/update-learnus-sesskey.ts
+++ b/src/core/login/update-learnus-sesskey.ts
@@ -2,7 +2,9 @@ import { sendMessageToTabs } from '../../utils/tab-message'
 import { LEARNUS_ORIGIN, LEARNUS_URL_PATTERN } from '../constants'
 
 export default async function updateLearnUsSesskey() {
-  const response = await fetch(LEARNUS_ORIGIN)
+  const response = await fetch(LEARNUS_ORIGIN, {
+    signal: AbortSignal.timeout(5000),
+  })
   const text = await response.text()
 
   const sesskey = text.match(/sesskey":"([^"]+)/)?.[1]


### PR DESCRIPTION
Fixes #42 
인터넷 상태가 불안정한 상황에서 fetch request가 비정상적으로 오래 걸릴 수 있다는 것이 문제라는 가설
크롬의 기본 timeout은 30초이기 때문에 5초로 줄임